### PR TITLE
Remove MiniApp view when fragment is destroyed

### DIFF
--- a/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppFragment.java
+++ b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeMiniAppFragment.java
@@ -7,11 +7,17 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
+import com.facebook.react.ReactRootView;
 
 public abstract class ElectrodeMiniAppFragment extends Fragment {
     private static final String INITIAL_PROPS = "props";
     private ElectrodeReactActivityListener mElectrodeReactActivityListener;
+
+    @Nullable
+    private View mMiniAppView;
 
     public void addInitialProps(@NonNull Bundle bundle) {
         Bundle args = new Bundle();
@@ -26,12 +32,14 @@ public abstract class ElectrodeMiniAppFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        Bundle initialProps = getArguments().getBundle(INITIAL_PROPS);
-        if (this.getActivity() != null && !this.getActivity().isFinishing()) {
-            return mElectrodeReactActivityListener.getElectrodeDelegate().createReactRootView(getMiniAppName(), initialProps);
-        } else {
-            return null;
+        if (mMiniAppView == null) {
+            Bundle initialProps = getArguments().getBundle(INITIAL_PROPS);
+            if (this.getActivity() != null && !this.getActivity().isFinishing()) {
+                mMiniAppView = mElectrodeReactActivityListener.getElectrodeDelegate()
+                        .createReactRootView(getMiniAppName(), initialProps);
+            }
         }
+        return mMiniAppView;
     }
 
     @Override
@@ -44,4 +52,14 @@ public abstract class ElectrodeMiniAppFragment extends Fragment {
                     + " must implement ElectrodeReactActivityListener");
         }
     }
-} 
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (mMiniAppView instanceof ReactRootView) {
+            mElectrodeReactActivityListener.getElectrodeDelegate()
+                    .removeMiniAppView(getMiniAppName(), (ReactRootView) mMiniAppView);
+            mMiniAppView = null;
+        }
+    }
+}


### PR DESCRIPTION
There's a memory leak when using `ElectrodeMiniAppFragment` because the views are cached in `mReactRootViews` ([ElectrodeReactActivityDelegate.java#L34](https://github.com/electrode-io/electrode-native/blob/830de3eac44c653741b6b93870e3411e41fa6f1b/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java#L34)) but they are never removed when the fragment is destroyed.
In this PR we are removing the view from the cache when the fragment is destroyed. We are following the logic used in [ElectrodeReactFragmentDelegate.java#L218](https://github.com/electrode-io/ernnavigation-api-impl-native/blob/785ba7716a6ac23970c418cc196e026bc72ab94c/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeReactFragmentDelegate.java#L218)